### PR TITLE
Correct checksum loop

### DIFF
--- a/parameters.h
+++ b/parameters.h
@@ -60,7 +60,7 @@ class FlashParameters
 
   uint32_t static CheckSum(const uint32_t *Word, uint32_t Words)                      // calculate check-sum of pointed data
   { uint32_t Check=CheckInit;
-    for(uint32_t Idx=0; Idx<Words; Words++)
+    for(uint32_t Idx=0; Idx<Words; Idx++)
     { Check+=Word[Idx]; }
     return Check; }
 


### PR DESCRIPTION
Not sure why this works with `-Os` optimizations (I guess the loop gets reduced to single `Check+=Word[0];` operation), but without compiler optimizations (`-O0`) MCU goes into (almost) infinite loop.