### PR TITLE
Silence beeper on startup

### DIFF
--- a/beep.cpp
+++ b/beep.cpp
@@ -27,7 +27,6 @@ void Beep_Configuration(void)
   TIM_OC3Init(TIM4, &TIM_OCStruct);                            // TIM4.CH3
   TIM_OC3PreloadConfig(TIM4, TIM_OCPreload_Enable);
 
-  TIM_OCStruct.TIM_OCPolarity  = TIM_OCPolarity_High;          // in anti-phase
   TIM_OC4Init(TIM4, &TIM_OCStruct);                            // TIM4.CH4
   TIM_OC4PreloadConfig(TIM4, TIM_OCPreload_Enable);
 


### PR DESCRIPTION
On my hardware this line causes device to emit loud sound out of the buzzer on startup until any other sound is played.

Not sure why this line is there, but we do `TIM_OC4PolarityConfig(TIM4, TIM_OCPolarity_Low);` in order to stop the sound in `Beep()` below, so setting polarity high in `Beep_Configuration` seems incorrect.