### PR TITLE
Wait longer for valid GPS signal before switching baud rate

### DIFF
--- a/gps.cpp
+++ b/gps.cpp
@@ -414,7 +414,7 @@ void vTaskGPS(void* pvParameters)
         Burst=0;
       }
 
-      if(NoValidData>=1000)                                                  // if no valid data from GPS for 1sec, then decide to switch the baudrate
+      if(NoValidData>=2000)                                                  // if no valid data from GPS for 2sec, then decide to switch the baudrate
       { GPS_Status.Flags=0;
         uint32_t NewBaudRate = GPS_nextBaudRate();
         xSemaphoreTake(CONS_Mutex, portMAX_DELAY);


### PR DESCRIPTION
GPS task seems to tune out from the right baud rate from time to time and start autobaud procedure even if it found the right baud rate before. On my device it is able to hold the correct baud rate just for several seconds.

I'm observing the following behavior without this patch: device outputs the GPS NMEA to console and then suddenly switches the GPS baud rate. 

```
...
$GPRMC,201147.00,V,,,,,,,130118,,,N*76
$GPGGA,201147.00,,,,,0,00,99.99,,,,,,*67
$GPGSA,A,1,,,,,,,,,,,,,99.99,99.99,99.99*30
$POGNB,47.0,+22.4,102000.0,1.0,-56.0,-59.3,+0.06,*75
$PGRMZ,-56.0,m,3*10
$POGNR,0,0,,-111.0,40,+22,+44.0,3.22*41
$POGNB,47.5,+22.4,102000.0,1.0,-56.0,-59.3,-0.06,*76
$PGRMZ,-56.0,m,3*10
TaskGPS: switch to 115200bps
...
```

I think this happens because GPS data rate is 1Hz - which is exactly equals to timeout of autobaud procedure. So even slight delay causes device to look for data on different baud rate. This bumps timeout to 2 seconds, which makes problem go away on my device.
