### PR TITLE
Only append \n to NMEA checksum

### DIFF
--- a/nmea.cpp
+++ b/nmea.cpp
@@ -15,5 +15,5 @@ uint8_t NMEA_AppendCheck(uint8_t *NMEA, uint8_t Len)
 
 uint8_t NMEA_AppendCheckCRNL(uint8_t *NMEA, uint8_t Len)
 { uint8_t CheckLen=NMEA_AppendCheck(NMEA, Len);
-  Len+=CheckLen; NMEA[Len]='\r'; NMEA[Len+1]='\n';
-  return CheckLen+2; }
+  Len+=CheckLen; NMEA[Len]='\n';
+  return CheckLen+1; }


### PR DESCRIPTION
We will convert `\n` to a proper `\r\n` sequence in `Format_String`
(and friends) before outputing it to serial console.

Without this, we are outputing strings with too many `\r` characters -
`\r\n` is converted to `\r\r\n` by `Format_String`. This makes output
unparseable by XCSoar.